### PR TITLE
Carlos/allow for easy addition of stablecoins

### DIFF
--- a/irma/programs/irma/src/lib.rs
+++ b/irma/programs/irma/src/lib.rs
@@ -9,6 +9,7 @@
 // };
 // use solana_sdk_ids::system_program;
 // use solana_program::{pubkey, pubkey::Pubkey};
+// use std::ffi::CStr;
 use bytemuck::bytes_of_mut;
 use anchor_lang::prelude::*;
 // use anchor_lang::{declare_id, program};
@@ -37,7 +38,6 @@ declare_id!("8zs1JbqxqLcCXzBrkMCXyY2wgSW8uk8nxYuMFEfUMQa6");
 pub mod iopenbook;
 pub mod pricing;
 
-use crate::pricing::Stablecoins;
 use crate::pricing::{ /* Initialize, */ IrmaCommon};
 use crate::pricing::{ /* initialize, */ set_mint_price, mint_irma, redeem_irma};
 use crate::iopenbook::{EventHeap, Market, ConsumeEvents, EventHeapHeader, EventNode, AnyEvent, OracleConfig};
@@ -261,15 +261,15 @@ pub fn crank<'info>(ctx: &Context<'_, 'info, '_, '_, CrankIrma<'info>>) -> Resul
 }
 
 #[repr(C)]
-pub enum OpenBookEvent {
+pub enum OpenBookEvent<'a> {
     BuyIRMA {
         trader: Pubkey,
-        quote_token: Stablecoins,
+        quote_token: &'a str,
         amount: u64,
     },
     SellIRMA {
         trader: Pubkey,
-        quote_token: Stablecoins,
+        quote_token: &'a str,
         irma_amount: u64,
     },
 }
@@ -292,7 +292,7 @@ pub fn handle_openbook_event(
 pub fn oracle_inflation_input<'info>(
     ctx: Context<'_, '_, '_, 'info, IrmaCommon<'info>>,
     inflation_percent: f64,
-    stablecoin: Stablecoins,
+    stablecoin: &str,
     stablecoin_price_usd: f64,
 ) -> Result<()> {
     let mint_price = if inflation_percent < 2.0 {

--- a/irma/programs/irma/src/pricing.rs
+++ b/irma/programs/irma/src/pricing.rs
@@ -122,6 +122,8 @@ pub fn redeem_irma(ctx: Context<IrmaCommon>, quote_token: &str, irma_amount: u64
     // There is a redemption rule: every redemption is limited to 100k IRMA or 10% of the IRMA in circulation (for
     // the quote token) whichever is smaller.
     let circulation: u64 = state.irma_in_circulation;
+    // let circulation: u64 = state.irma_in_circulation * (10u64.pow(state.backing_decimals as u32));
+    // require!(circulation > 0, CustomError::InsufficientCirculation);
     let irma_amount = (irma_amount as f64 / (10.0_f64).powf(IRMA.backing_decimals as f64)) as f64;
     require!((irma_amount <= 100_000.0) && (irma_amount <= circulation as f64 / 10.0), CustomError::InvalidIrmaAmount);
 

--- a/irma/programs/irma/src/pricing.rs
+++ b/irma/programs/irma/src/pricing.rs
@@ -30,61 +30,9 @@ pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
     state.bump = 13u8; // InitializeBumps::bump(&ctx.bumps).unwrap_or(0);
     msg!("State initialized with bump: {}", state.bump);
 
-    //     symbol: Box::new(symbols[0].to_string()), // symbol of the stablecoin, e.g. "USDT"
-    //     mint_address: pubkey!("Es9vMFrzaTmVRL3P15S3BtQDvVwWZEzPDk1e45sA2v6p"), // USDT mint address on Solana
-    let usdt = StableState::new(
-        "USDT",
-        pubkey!("Es9vMFrzaTmVRL3P15S3BtQDvVwWZEzPDk1e45sA2v6p"), // USDT mint address on Solana
-        6,
-    )?;
-    state.add_stablecoin(usdt);
+    state.add_initial_stablecoins()?;
+    msg!("Initial stablecoins added to the state.");
 
-    //     symbol: Box::new(symbols[1].to_string()), // symbol of the stablecoin, e.g. "USDC"
-    //     mint_address: pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"), // USDC mint address on Solana
-    let usdc = StableState::new(
-        "USDC",
-        pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"), // USDT mint address on Solana
-        6,
-    )?;
-    state.add_stablecoin(usdc);
-
-    //     symbol: Box::new(symbols[2].to_string()),
-    //     mint_address: pubkey!("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo"), // PYUSD mint address on Solana
-    let pyusd = StableState::new(
-        "PYUSD",
-        pubkey!("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo"), // USDT mint address on Solana
-        6,
-    )?;
-    state.add_stablecoin(pyusd);
-
-    //     symbol: Box::new(symbols[3].to_string()),
-    //     mint_address: pubkey!("USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA"), // USDS mint address on Solana
-    let usds = StableState::new(
-        "USDS",
-        pubkey!("USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA"), // USDT mint address on Solana
-        6,
-    )?;
-    state.add_stablecoin(usds);
-
-    //     symbol: Box::new(symbols[4].to_string()),
-    //     mint_address: pubkey!("2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH"), // USDG mint address on Solana
-    let usdg = StableState::new(
-        "USDG",
-        pubkey!("2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH"), // USDT mint address on Solana
-        6,
-    )?;
-    state.add_stablecoin(usdg);
-
-    //     symbol: Box::new(symbols[5].to_string()),
-    //     mint_address: pubkey!("9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u"), // FDUSD mint address on Solana
-    let fdusd = StableState::new(
-        "FDUSD",
-        pubkey!("9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u"), // USDT mint address on Solana
-        6,
-    )?;
-    state.add_stablecoin(fdusd);
-
-    msg!("BTreeMap length: {:?}", state.reserves.len());
     Ok(())
 }
 
@@ -327,6 +275,86 @@ impl StateMap {
     pub fn len(&self) -> usize {
         self.reserves.len()
     }
+
+    pub fn add_initial_stablecoins(&mut self) -> Result<()> {
+        // This function is used to add initial stablecoins to the reserves.
+        // It is called during the initialization of the IRMA program.
+        // let usdt = StableState::new("USDT", pubkey!("Es9vMFrzaTmVRL3P15S3BtQDvVwWZEzPDk1e45sA2v6p"), 6)?;
+        // self.add_stablecoin(usdt);
+        
+        // let usdc = StableState::new("USDC", pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"), 6)?;
+        // self.add_stablecoin(usdc);
+        
+        // let pyusd = StableState::new("PYUSD", pubkey!("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo"), 6)?;
+        // self.add_stablecoin(pyusd);
+        
+        // let usds = StableState::new("USDS", pubkey!("USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA"), 6)?;
+        // self.add_stablecoin(usds);
+        
+        // let usdg = StableState::new("USDG", pubkey!("2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH"), 6)?;
+        // self.add_stablecoin(usdg);
+        
+        // let fdusd = StableState::new("FDUSD", pubkey!("9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u"), 6)?;
+        // self.add_stablecoin(fdusd);
+
+        // Ok(())
+        //     symbol: Box::new(symbols[0].to_string()), // symbol of the stablecoin, e.g. "USDT"
+        //     mint_address: pubkey!("Es9vMFrzaTmVRL3P15S3BtQDvVwWZEzPDk1e45sA2v6p"), // USDT mint address on Solana
+        let usdt = StableState::new(
+            "USDT",
+            pubkey!("Es9vMFrzaTmVRL3P15S3BtQDvVwWZEzPDk1e45sA2v6p"), // USDT mint address on Solana
+            6,
+        )?;
+        self.add_stablecoin(usdt);
+
+        //     symbol: Box::new(symbols[1].to_string()), // symbol of the stablecoin, e.g. "USDC"
+        //     mint_address: pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"), // USDC mint address on Solana
+        let usdc = StableState::new(
+            "USDC",
+            pubkey!("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"), // USDT mint address on Solana
+            6,
+        )?;
+        self.add_stablecoin(usdc);
+
+        //     symbol: Box::new(symbols[2].to_string()),
+        //     mint_address: pubkey!("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo"), // PYUSD mint address on Solana
+        let pyusd = StableState::new(
+            "PYUSD",
+            pubkey!("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo"), // USDT mint address on Solana
+            6,
+        )?;
+        self.add_stablecoin(pyusd);
+
+        //     symbol: Box::new(symbols[3].to_string()),
+        //     mint_address: pubkey!("USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA"), // USDS mint address on Solana
+        let usds = StableState::new(
+            "USDS",
+            pubkey!("USDSwr9ApdHk5bvJKMjzff41FfuX8bSxdKcR81vTwcA"), // USDT mint address on Solana
+            6,
+        )?;
+        self.add_stablecoin(usds);
+
+        //     symbol: Box::new(symbols[4].to_string()),
+        //     mint_address: pubkey!("2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH"), // USDG mint address on Solana
+        let usdg = StableState::new(
+            "USDG",
+            pubkey!("2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH"), // USDT mint address on Solana
+            6,
+        )?;
+        self.add_stablecoin(usdg);
+
+        //     symbol: Box::new(symbols[5].to_string()),
+        //     mint_address: pubkey!("9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u"), // FDUSD mint address on Solana
+        let fdusd = StableState::new(
+            "FDUSD",
+            pubkey!("9zNQRsGLjNKwCUU5Gq5LR8beUCPzQMVMqKAi3SSZh54u"), // USDT mint address on Solana
+            6,
+        )?;
+        self.add_stablecoin(fdusd);
+
+        msg!("BTreeMap length: {:?}", self.reserves.len());
+        Ok(())
+    }  
 
     /// ReduceCirculations implementation
     /// This now deals with mint_price being less than redemption_price (a period of deflation).

--- a/irma/programs/irma/tests/unit.rs
+++ b/irma/programs/irma/tests/unit.rs
@@ -26,7 +26,7 @@ mod tests {
         let reserves = &mut state.reserves;
         let usdt: StableState = StableState::new("USDT", pubkey!("Es9vMFrzaTmVRL3P15S3BtQDvVwWZEzPDk1e45sA2v6p"), 6 as u64).unwrap();
         reserves.insert("USDT".to_string(), usdt);
-        assert_eq!(reserves.len(), 0);
+        assert_eq!(reserves.len(), 1);
         state
     }
 
@@ -544,7 +544,7 @@ mod tests {
         // Test for near maximum redemption, multiple times, until it fails.
         // What we expect is that these repeated redemptions will equalize the differences between
         // mint prices and redemptions prices for all stablecoins.
-        let mut reslt = redeem_irma(ctx, "USDT", 100_000);
+        let mut reslt = redeem_irma(ctx, "FDUSD", 100_000_000_000);
         while reslt.is_ok() {
             ctx = Context::new(
                 program_id,
@@ -552,7 +552,7 @@ mod tests {
                 &[],
                 IrmaCommonBumps::default(), // Use default bumps if not needed
             );
-            reslt = redeem_irma(ctx, "USDT", 100_000_000_000);
+            reslt = redeem_irma(ctx, "FDUSD", 100_000_000_000);
             match reslt {
                 Err(e) => {
                     msg!("Error redeeming IRMA for USDT: {:?}", e);


### PR DESCRIPTION
Define a struct for each backing stablecoin instead of using disparate arrays for each value. Put all stablecoin data in a BTreeMap. These two big changes has made it very easy to add any new stablecoin that comes along.

Now the only thing to do is complete the interface to OpenBook V2 and add more test cases.