### PR TITLE
Disable iopenbook.rs for now

### DIFF
--- a/irma/Anchor.toml
+++ b/irma/Anchor.toml
@@ -16,4 +16,4 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 2000000 tests/**/*.ts"

--- a/irma/programs/irma/src/lib.rs
+++ b/irma/programs/irma/src/lib.rs
@@ -41,12 +41,12 @@ use anchor_lang::{
 // use anchor_lang::system_program::ID;
 
 
-pub mod iopenbook;
+// pub mod iopenbook;
 pub mod pricing;
 
 
-use iopenbook::{EventHeap, Market, ConsumeEvents, EventHeapHeader, EventNode, AnyEvent, OracleConfig};
-use iopenbook::{/*OpenBookV2,*/ get_latest_slot, consume_given_events, MAX_NUM_EVENTS};
+// use iopenbook::{EventHeap, Market, ConsumeEvents, EventHeapHeader, EventNode, AnyEvent, OracleConfig};
+// use iopenbook::{/*OpenBookV2,*/ get_latest_slot, consume_given_events, MAX_NUM_EVENTS};
 use pricing::{
     mint_irma,
     redeem_irma,
@@ -95,7 +95,7 @@ pub mod irma {
     /// This is a permissioned instruction that can only be called by the IRMA program owner.
     /// The minimum requirement is that the stablecoin has 100M circulating supply and is not a meme coin.
     /// IRMA relies on pre-existing network effects of each of the reserve stablecoins.
-    pub fn add_stablecoin(ctx: Context<Init>, symbol: String, mint_address: Pubkey, decimals: u8) -> Result<()> {
+    pub fn add_stablecoin(ctx: Context<Maint>, symbol: String, mint_address: Pubkey, decimals: u8) -> Result<()> {
         pricing::add_stablecoin(ctx, &symbol, mint_address, decimals)
     }
 
@@ -106,7 +106,7 @@ pub mod irma {
     /// then disable or deactivate the stablecoin to be removed (A), and then do a loop of
     /// 1. internally swapping 100k of stablecoin B for stablecoin A, and then
     /// 2. externally swapping 100k of stablecoin A for 100k of stablecoin B (open market).
-    pub fn remove_stablecoin(ctx: Context<Init>, symbol: String) -> Result<()> {
+    pub fn remove_stablecoin(ctx: Context<Maint>, symbol: String) -> Result<()> {
         pricing::remove_reserve(ctx, &symbol)
     }
 
@@ -115,7 +115,7 @@ pub mod irma {
     /// The only action that is disabled should be the minting of IRMA using this reserve stablecoin.
     /// This is done in preparation for removing the stablecoin from the reserves.
     /// For orderly removal, first announce separate dates of deactivation and removal.
-    pub fn disable_reserve(ctx: Context<Init>, symbol: String) -> Result<()> {
+    pub fn disable_reserve(ctx: Context<Maint>, symbol: String) -> Result<()> {
         pricing::disable_reserve(ctx, &symbol)
     }
 
@@ -128,7 +128,7 @@ pub mod irma {
 
 fn crank_market(ctx: Context<Crk>) -> Result<()> {
     let state = ctx.accounts.state.load_mut()?;
-    let slots = get_latest_slot()?;
+    // let slots = get_latest_slot()?;
 
     msg!("Cranking IRMA with pubkey: {:?}", state.pubkey);
 
@@ -149,194 +149,194 @@ fn crank_market(ctx: Context<Crk>) -> Result<()> {
         0,
     );
 
-    fn alloc_heap<'info>() -> &'info mut EventHeap {
-        let heap = EventHeap {
-            header: EventHeapHeader {
-                free_head: 0u16,
-                used_head: 0u16,
-                count: 0u16,
-                _padd: 0u16,
-                seq_num: 0u64,
-            },
-            nodes: [EventNode {
-                next: 0u16,
-                prev: 0u16,
-                _pad: [0u8; 4],
-                event: AnyEvent {
-                    event_type: 0u8, // Placeholder for event type
-                    padding: [0u8; 143], // Placeholder for event data
-                },
-            }; MAX_NUM_EVENTS as usize],
-            reserved: [0u8; 64],
-        };
-        Box::leak(Box::new(heap))
-    }
+    // fn alloc_heap<'info>() -> &'info mut EventHeap {
+    //     let heap = EventHeap {
+    //         header: EventHeapHeader {
+    //             free_head: 0u16,
+    //             used_head: 0u16,
+    //             count: 0u16,
+    //             _padd: 0u16,
+    //             seq_num: 0u64,
+    //         },
+    //         nodes: [EventNode {
+    //             next: 0u16,
+    //             prev: 0u16,
+    //             _pad: [0u8; 4],
+    //             event: AnyEvent {
+    //                 event_type: 0u8, // Placeholder for event type
+    //                 padding: [0u8; 143], // Placeholder for event data
+    //             },
+    //         }; MAX_NUM_EVENTS as usize],
+    //         reserved: [0u8; 64],
+    //     };
+    //     Box::leak(Box::new(heap))
+    // }
 
-    let program_id: &'static Pubkey = &IRMA_ID;
-    let events_acct: Pubkey = Pubkey::find_program_address(&[b"eventheap".as_ref()], program_id).0;
-    let lamports: &'static mut u64 = Box::leak(Box::new(100000u64));
-    let event_heap: &'_ mut EventHeap = alloc_heap();
+    // let program_id: &'static Pubkey = &IRMA_ID;
+    // let events_acct: Pubkey = Pubkey::find_program_address(&[b"eventheap".as_ref()], program_id).0;
+    // let lamports: &'static mut u64 = Box::leak(Box::new(100000u64));
+    // let event_heap: &'_ mut EventHeap = alloc_heap();
 
-    let events_data: &'_ mut [u8] = bytemuck::bytes_of_mut(event_heap);
-    let events_key: &'_ mut Pubkey = Box::leak(Box::new(events_acct));
-    msg!("Events account key: {:?}", events_key);
+    // let events_data: &'_ mut [u8] = bytemuck::bytes_of_mut(event_heap);
+    // let events_key: &'_ mut Pubkey = Box::leak(Box::new(events_acct));
+    // msg!("Events account key: {:?}", events_key);
 
-    let events_info: AccountInfo<'_> = AccountInfo::new(
-        events_key,
-        false,
-        false,
-        lamports,
-        events_data,
-        program_id, // owner
-        false,
-        0,
-    );
-    let events_info: &AccountInfo<'_> = Box::leak(Box::new(events_info));
+    // let events_info: AccountInfo<'_> = AccountInfo::new(
+    //     events_key,
+    //     false,
+    //     false,
+    //     lamports,
+    //     events_data,
+    //     program_id, // owner
+    //     false,
+    //     0,
+    // );
+    // let events_info: &AccountInfo<'_> = Box::leak(Box::new(events_info));
 
-    let signer_info: &AccountInfo<'_> = Box::leak(Box::new(ctx.accounts.signer.to_account_info()));
-    let sys_program: &AccountInfo<'_> = Box::leak(Box::new(ctx.accounts.system_program.to_account_info()));
+    // let signer_info: &AccountInfo<'_> = Box::leak(Box::new(ctx.accounts.signer.to_account_info()));
+    // let sys_program: &AccountInfo<'_> = Box::leak(Box::new(ctx.accounts.system_program.to_account_info()));
 
-    fn alloc_mkt(ekey: Pubkey) -> Market {
-        Market {
-            // PDA bump
-            bump: 0u8,
-            pad1: [0u8; 7],
-            // Number of decimals used for the base token.
-            //
-            // Used to convert the oracle's price into a native/native price.
-            base_decimals: 0u8,
-            pad2: [0u8; 7],
-            quote_decimals: 0u8,
-            pad3: [0u8; 7],
-            // padding1: [0u8; 5],
+    // fn alloc_mkt(ekey: Pubkey) -> Market {
+    //     Market {
+    //         // PDA bump
+    //         bump: 0u8,
+    //         pad1: [0u8; 7],
+    //         // Number of decimals used for the base token.
+    //         //
+    //         // Used to convert the oracle's price into a native/native price.
+    //         base_decimals: 0u8,
+    //         pad2: [0u8; 7],
+    //         quote_decimals: 0u8,
+    //         pad3: [0u8; 7],
+    //         // padding1: [0u8; 5],
 
-            // Pda for signing vault txs
-            market_authority: Pubkey::new_unique(),
+    //         // Pda for signing vault txs
+    //         market_authority: Pubkey::new_unique(),
 
-            // No expiry = 0. Market will expire and no trading allowed after time_expiry
-            time_expiry: 0i64,
+    //         // No expiry = 0. Market will expire and no trading allowed after time_expiry
+    //         time_expiry: 0i64,
 
-            // Admin who can collect fees from the market
-            collect_fee_admin: Pubkey::new_unique(),
-            // Admin who must sign off on all order creations
-            open_orders_admin: Pubkey::new_unique(), // NonZeroPubkeyOption,
-            // Admin who must sign off on all event consumptions
-            consume_events_admin: Pubkey::new_unique(), // NonZeroPubkeyOption,
-            // Admin who can set market expired, prune orders and close the market
-            close_market_admin: Pubkey::new_unique(), // NonZeroPubkeyOption,
+    //         // Admin who can collect fees from the market
+    //         collect_fee_admin: Pubkey::new_unique(),
+    //         // Admin who must sign off on all order creations
+    //         open_orders_admin: Pubkey::new_unique(), // NonZeroPubkeyOption,
+    //         // Admin who must sign off on all event consumptions
+    //         consume_events_admin: Pubkey::new_unique(), // NonZeroPubkeyOption,
+    //         // Admin who can set market expired, prune orders and close the market
+    //         close_market_admin: Pubkey::new_unique(), // NonZeroPubkeyOption,
 
-            // Name. Trailing zero bytes are ignored.
-            name: [0u8; 16],
+    //         // Name. Trailing zero bytes are ignored.
+    //         name: [0u8; 16],
 
-            // Address of the BookSide account for bids
-            bids: Pubkey::new_unique(),
-            // Address of the BookSide account for asks
-            asks: Pubkey::new_unique(),
-            // Address of the EventHeap account
-            event_heap: ekey,
+    //         // Address of the BookSide account for bids
+    //         bids: Pubkey::new_unique(),
+    //         // Address of the BookSide account for asks
+    //         asks: Pubkey::new_unique(),
+    //         // Address of the EventHeap account
+    //         event_heap: ekey,
 
-            // Oracles account address
-            oracle_a: Pubkey::new_unique(), // NonZeroPubkeyOption,
-            oracle_b: Pubkey::new_unique(), // NonZeroPubkeyOption,
-            // Oracle configuration
-            oracle_config: OracleConfig {
-                conf_filter: 0f64,
-                max_staleness_slots: 0i64,
-                reserved: [0u8; 72],
-            },
-            pad4: [0u8; 8],
+    //         // Oracles account address
+    //         oracle_a: Pubkey::new_unique(), // NonZeroPubkeyOption,
+    //         oracle_b: Pubkey::new_unique(), // NonZeroPubkeyOption,
+    //         // Oracle configuration
+    //         oracle_config: OracleConfig {
+    //             conf_filter: 0f64,
+    //             max_staleness_slots: 0i64,
+    //             reserved: [0u8; 72],
+    //         },
+    //         pad4: [0u8; 8],
 
-            // Number of quote native in a quote lot. Must be a power of 10.
-            //
-            // Primarily useful for increasing the tick size on the market: A lot price
-            // of 1 becomes a native price of quote_lot_size/base_lot_size becomes a
-            // ui price of quote_lot_size*base_decimals/base_lot_size/quote_decimals.
-            quote_lot_size: 6i64,
+    //         // Number of quote native in a quote lot. Must be a power of 10.
+    //         //
+    //         // Primarily useful for increasing the tick size on the market: A lot price
+    //         // of 1 becomes a native price of quote_lot_size/base_lot_size becomes a
+    //         // ui price of quote_lot_size*base_decimals/base_lot_size/quote_decimals.
+    //         quote_lot_size: 6i64,
 
-            // Number of base native in a base lot. Must be a power of 10.
-            //
-            // Example: If base decimals for the underlying asset is 6, base lot size
-            // is 100 and and base position lots is 10_000 then base position native is
-            // 1_000_000 and base position ui is 1.
-            base_lot_size: 6i64,
+    //         // Number of base native in a base lot. Must be a power of 10.
+    //         //
+    //         // Example: If base decimals for the underlying asset is 6, base lot size
+    //         // is 100 and and base position lots is 10_000 then base position native is
+    //         // 1_000_000 and base position ui is 1.
+    //         base_lot_size: 6i64,
 
-            // Total number of orders seen
-            seq_num: 0u64,
+    //         // Total number of orders seen
+    //         seq_num: 0u64,
 
-            // Timestamp in seconds that the market was registered at.
-            registration_time: 0i64,
+    //         // Timestamp in seconds that the market was registered at.
+    //         registration_time: 0i64,
 
-            // Fees
-            //
-            // Fee (in 10^-6) when matching maker orders.
-            // maker_fee < 0 it means some of the taker_fees goes to the maker
-            // maker_fee > 0, it means no taker_fee to the maker, and maker fee goes to the referral
-            maker_fee: -10000i64,
-            // Fee (in 10^-6) for taker orders, always >= 0.
-            taker_fee: 12000i64,
+    //         // Fees
+    //         //
+    //         // Fee (in 10^-6) when matching maker orders.
+    //         // maker_fee < 0 it means some of the taker_fees goes to the maker
+    //         // maker_fee > 0, it means no taker_fee to the maker, and maker fee goes to the referral
+    //         maker_fee: -10000i64,
+    //         // Fee (in 10^-6) for taker orders, always >= 0.
+    //         taker_fee: 12000i64,
 
-            // Total fees accrued in native quote
-            fees_accrued: 0u128,
-            // Total fees settled in native quote
-            fees_to_referrers: 0u128,
+    //         // Total fees accrued in native quote
+    //         fees_accrued: 0u128,
+    //         // Total fees settled in native quote
+    //         fees_to_referrers: 0u128,
 
-            // Referrer rebates to be distributed
-            referrer_rebates_accrued: 0u64,
+    //         // Referrer rebates to be distributed
+    //         referrer_rebates_accrued: 0u64,
 
-            // Fees generated and available to withdraw via sweep_fees
-            fees_available: 0u64,
+    //         // Fees generated and available to withdraw via sweep_fees
+    //         fees_available: 0u64,
 
-            // Cumulative maker volume (same as taker volume) in quote native units
-            maker_volume: 0u128,
+    //         // Cumulative maker volume (same as taker volume) in quote native units
+    //         maker_volume: 0u128,
 
-            // Cumulative taker volume in quote native units due to place take orders
-            taker_volume_wo_oo: 0u128,
+    //         // Cumulative taker volume in quote native units due to place take orders
+    //         taker_volume_wo_oo: 0u128,
 
-            base_mint: Pubkey::new_from_array([0u8; 32]), //  IRMA mint
-            quote_mint: Pubkey::new_from_array([0u8; 32]), // Stablecoin mint
+    //         base_mint: Pubkey::new_from_array([0u8; 32]), //  IRMA mint
+    //         quote_mint: Pubkey::new_from_array([0u8; 32]), // Stablecoin mint
 
-            market_base_vault: Pubkey::new_unique(),
-            base_deposit_total: 100u64,
+    //         market_base_vault: Pubkey::new_unique(),
+    //         base_deposit_total: 100u64,
 
-            market_quote_vault: Pubkey::new_unique(),
-            quote_deposit_total: 100u64,
+    //         market_quote_vault: Pubkey::new_unique(),
+    //         quote_deposit_total: 100u64,
 
-            reserved: [0u8; 128],
-        }
-    }
+    //         reserved: [0u8; 128],
+    //     }
+    // }
     
-    let market_acct: Pubkey = Pubkey::find_program_address(&[b"market".as_ref()], program_id).0;
-    let lamports: &'static mut u64 = Box::leak(Box::new(100000u64));
-    let boxed_market = Box::new(alloc_mkt(*events_key));
-    let market: &'static mut Market = Box::leak(boxed_market);
+    // let market_acct: Pubkey = Pubkey::find_program_address(&[b"market".as_ref()], program_id).0;
+    // let lamports: &'static mut u64 = Box::leak(Box::new(100000u64));
+    // let boxed_market = Box::new(alloc_mkt(*events_key));
+    // let market: &'static mut Market = Box::leak(boxed_market);
 
-    let market_data: &'_ mut [u8] = bytemuck::bytes_of_mut(market);
-    let market_key: &'_ mut Pubkey = Box::leak(Box::new(market_acct));
-    msg!("Market account key: {:?}", market_key);
+    // let market_data: &'_ mut [u8] = bytemuck::bytes_of_mut(market);
+    // let market_key: &'_ mut Pubkey = Box::leak(Box::new(market_acct));
+    // msg!("Market account key: {:?}", market_key);
 
-    let market_info: AccountInfo = AccountInfo::new(
-        market_key,
-        false,
-        false,
-        lamports,
-        market_data,
-        program_id, // owner
-        false,
-        0,
-    );
-    let market_info: &AccountInfo<'_> = Box::leak(Box::new(market_info));
+    // let market_info: AccountInfo = AccountInfo::new(
+    //     market_key,
+    //     false,
+    //     false,
+    //     lamports,
+    //     market_data,
+    //     program_id, // owner
+    //     false,
+    //     0,
+    // );
+    // let market_info: &AccountInfo<'_> = Box::leak(Box::new(market_info));
 
-    let this_ctx = CpiContext::new(
-        dummy_info,
-        ConsumeEvents {
-            consume_events_admin: Signer::try_from(signer_info).unwrap(),
-            event_heap: AccountLoader::<'_ , EventHeap>::try_from(events_info).unwrap(),
-            market: AccountLoader::<'_ , Market>::try_from(market_info).unwrap(),
-            system_program: Program::try_from(sys_program).unwrap(),
-        },
-    );
+    // let this_ctx = CpiContext::new(
+    //     dummy_info,
+    //     ConsumeEvents {
+    //         consume_events_admin: Signer::try_from(signer_info).unwrap(),
+    //         event_heap: AccountLoader::<'_ , EventHeap>::try_from(events_info).unwrap(),
+    //         market: AccountLoader::<'_ , Market>::try_from(market_info).unwrap(),
+    //         system_program: Program::try_from(sys_program).unwrap(),
+    //     },
+    // );
 
-    consume_given_events(this_ctx, slots)?;
+    // consume_given_events(this_ctx, slots)?;
     Ok(())
 }
 
@@ -426,6 +426,16 @@ pub struct Common<'info> {
     pub state: Account<'info, StateMap>,
     #[account(mut)]
     pub trader: Signer<'info>,
+    #[account(address = system_program::ID)]
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct Maint<'info> {
+    #[account(mut, seeds=[b"state".as_ref()], bump)]
+    pub state: Account<'info, StateMap>,
+    #[account(mut)]
+    pub irma_admin: Signer<'info>,
     #[account(address = system_program::ID)]
     pub system_program: Program<'info, System>,
 }

--- a/irma/programs/irma/src/pricing.rs
+++ b/irma/programs/irma/src/pricing.rs
@@ -22,8 +22,7 @@ use anchor_lang::prelude::*;
 use Vec;
 use std::collections::BTreeMap;
 
-use crate::Init;
-use crate::Common;
+use crate::{Init, Common, Maint};
 // use crate::StateMap;
 // use crate::StableState;
 // use crate::IRMA;
@@ -31,7 +30,8 @@ use crate::Common;
 // The number of stablecoins that are initially supported by the IRMA program.
 pub const BACKING_COUNT: usize = 6 as usize;
 // Maximum number of stablecoins supported
-pub const MAX_BACKING_COUNT: usize = 100;
+// This is limited by the maximum size of the account data (10,240 bytes)
+pub const MAX_BACKING_COUNT: usize = 85;
 
 declare_id!("8zs1JbqxqLcCXzBrkMCXyY2wgSW8uk8nxYuMFEfUMQa6");
 
@@ -58,7 +58,7 @@ pub fn init_pricing(ctx: Context<Init>) -> Result<()> {
 
 /// The whole purpose for using a BTreeMap (now a Vec) is to allow for easy addition of new stablecoins.
 pub fn add_stablecoin(
-        ctx: Context<Init>, 
+        ctx: Context<Maint>, 
         symbol: &str, 
         mint_address: prelude::Pubkey,
         backing_decimals: u8) -> Result<()> 
@@ -75,7 +75,7 @@ pub fn add_stablecoin(
 }
 
 /// Remove a stablecoin from the reserves by its symbol.
-pub fn remove_reserve(ctx: Context<Init>, symbol: &str) -> Result<()> {
+pub fn remove_reserve(ctx: Context<Maint>, symbol: &str) -> Result<()> {
     let state = &mut ctx.accounts.state;
     if !state.contains_reserve(symbol) {
         msg!("Stablecoin {} not found in reserves.", symbol);
@@ -87,7 +87,7 @@ pub fn remove_reserve(ctx: Context<Init>, symbol: &str) -> Result<()> {
 }
 
 /// Deactivate a reserve stablecoin.
-pub fn disable_reserve(ctx: Context<Init>, symbol: &str) -> Result<()> {
+pub fn disable_reserve(ctx: Context<Maint>, symbol: &str) -> Result<()> {
     let state = &mut ctx.accounts.state;
     if !state.contains_reserve(symbol) {
         msg!("Stablecoin {} not found in reserves.", symbol);

--- a/irma/tests/irma.ts
+++ b/irma/tests/irma.ts
@@ -19,12 +19,6 @@ describe("irma", () => {
   let stateBump: number;
 
   before(async () => {
-    // Find PDA for state
-    [statePda, stateBump] = anchor.web3.PublicKey.findProgramAddressSync(
-      [stateSeed],
-      program.programId
-    );
-
     // Airdrop SOL to irmaAdmin for testing
     const sig = await provider.connection.requestAirdrop(
       irmaAdmin.publicKey,
@@ -34,7 +28,13 @@ describe("irma", () => {
     await provider.connection.confirmTransaction(sig, config);
   });
 
-  it("Initializes IRMA state", async () => {
+  it("Initializes IRMA state, then adds a stablecoin", async () => {
+    // Find PDA for state
+    [statePda, stateBump] = anchor.web3.PublicKey.findProgramAddressSync(
+      [stateSeed],
+      program.programId
+    );
+
     await program.methods
       .initialize()
       .accounts({
@@ -44,6 +44,8 @@ describe("irma", () => {
       })
       .signers([irmaAdmin])
       .rpc();
+
+    console.log("IRMA state initialized with PDA:", statePda.toBase58());
 
     // Fetch the state account and check values
     const stateAccount = await program.account.stateMap.fetch(statePda);
@@ -56,6 +58,8 @@ describe("irma", () => {
     const mintAddress = anchor.web3.Keypair.generate().publicKey;
     const decimals = 6;
 
+    console.log("Adding stablecoin:", symbol, "Mint Address:", mintAddress.toBase58(), "Decimals:", decimals);
+
     await program.methods
       .addStablecoin(symbol, mintAddress, decimals)
       .accounts({
@@ -65,6 +69,8 @@ describe("irma", () => {
       })
       .signers([irmaAdmin])
       .rpc();
+    
+    console.log("Stablecoin added:", symbol);
 
     // Fetch and check state changes as needed
     const stateAccount = await program.account.stateMap.fetch(statePda);


### PR DESCRIPTION
All Rust and Typescript tests run, but I had to disable iopenbook.rs to avoid the ELF parsing error durin deployment. Something in iopenbook.rs is generating a long symbol name. I need to find it before I can add iopenbook.rs back.